### PR TITLE
fix: add missing peer dep lost in cdcde37

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,18 @@
     "lodash": "^4.17.21",
     "tapable": "^2.0.0"
   },
+  "peerDependencies": {
+    "@rspack/core": "0.x || 1.x",
+    "webpack": "^5.20.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    },
+    "webpack": {
+      "optional": true
+    }
+  },
   "keywords": [
     "rspack",
     "plugin",


### PR DESCRIPTION
peer dep for webpack and rspack exists before https://github.com/rspack-contrib/html-rspack-plugin/commit/cdcde37690713b56780a70c3208be853f4f25d6f https://github.com/rspack-contrib/html-rspack-plugin/blob/ebfa1cecdace8a75a6a167e70aac4f0e0ad90121/package.json#L58-L69

But lost in https://github.com/rspack-contrib/html-rspack-plugin/commit/cdcde37690713b56780a70c3208be853f4f25d6f when merging. This PR brings it back.

cc @chenjiahan since no one is watching this repository on GitHub for now.