### PR TITLE
fix: remove webpack from peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Change list:
 
 - Import type from `@rspack/core`
 - Inline `@types/html-minifier-terser` package
-- Remove `pretty-error` dependency
 - Bump `html-minifier-terser` from v6 to v7
+- Remove `pretty-error` dependency
+- Remove `webpack` peer dependency
 - Prebundle `html-minifier-terser`
 
 <h2 align="center">Install</h2>

--- a/package.json
+++ b/package.json
@@ -54,14 +54,10 @@
     "tapable": "^2.0.0"
   },
   "peerDependencies": {
-    "@rspack/core": "0.x || 1.x",
-    "webpack": "^5.20.0"
+    "@rspack/core": "0.x || 1.x"
   },
   "peerDependenciesMeta": {
     "@rspack/core": {
-      "optional": true
-    },
-    "webpack": {
       "optional": true
     }
   },


### PR DESCRIPTION
Remove webpack from peer dependencies:

- this plugin is Rspack-only, webpack projects should use the official html-webpack-plugin.
- the webpack peer dependencies will generate unexpected transitivePeerDependencies when using pnpm:

![img_v3_028p_c5822bda-bd72-4844-876d-8d14b4e0833g](https://github.com/rspack-contrib/html-rspack-plugin/assets/7237365/00d54fab-d16c-48eb-8185-2b1f4f1acf9f)
