### PR TITLE
fix: error message mutation in toString method

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -11,7 +11,7 @@ module.exports = function (err) {
     },
     toString: function () {
       if (err.message) {
-        err.message = `[html-rspack-plugin]: ` + err.message; 
+        return `[html-rspack-plugin]: ` + err.message; 
       }
       return err;
     }


### PR DESCRIPTION
Don't think this was intentional, and many errors have non-writable `message` fields so the old code would throw instead of returning a string at all.