### PR TITLE
chore: support TypeScript 7 module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "module": "commonjs",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     "resolveJsonModule": true,


### PR DESCRIPTION
TypeScript 7 removes the legacy `node` (`node10`) module resolver, causing `tsc` to fail before checking source files. This PR keeps the package's CommonJS semantics explicit and switches module resolution to the supported `bundler` mode.

## Related Links

- https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-beta/